### PR TITLE
Support for authorization status and addition of authorization type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
 # CoreLocationMiddleware
 
-A description of this package.
+This is a [Middleware](https://github.com/SwiftRex/SwiftRex#middleware) for [SwiftRex](https://github.com/SwiftRex/SwiftRex) which acts as a [CoreLocation](https://developer.apple.com/documentation/corelocation) delegate.
+
+## Current features implemented
+
+The middleware plugin currently provides the following features : 
+* start / stop standard (as opposed to significant location change) location monitoring.
+* listens to [location updates](https://developer.apple.com/documentation/corelocation/cllocationmanagerdelegate/1423615-locationmanager) from the CLLocationManager delegate and dispatches the CLLocation data back to the store
+* listens to [authorization changes](https://developer.apple.com/documentation/corelocation/cllocationmanagerdelegate/3563956-locationmanagerdidchangeauthoriz) from the CLLocationManager delegate and dispatches the authorization status back to the store
+
+## Future enhancements
+
+The following additions are expected : 
+* support for region monitoring
+* support for iBeacon ranging
+* support for visit-related events
+* support for heading updates
+* support for significant location changes (SLC)
+
+# Companion product
+
+We've made available a companion application to test the features provided by CoreLocationMiddleware : 
+https://github.com/npvisual/CoreLocation-Redux

--- a/Sources/CoreLocationMiddleware/CoreLocationMiddleware.swift
+++ b/Sources/CoreLocationMiddleware/CoreLocationMiddleware.swift
@@ -2,9 +2,15 @@ import CoreLocation
 import SwiftRex
 
 public struct LocationState: Equatable {
-    public var authzType: AuthzType = .whenInUse
-    public var authzStatus: CLAuthorizationStatus
-    public var location: CLLocation
+    var authzType: AuthzType = .whenInUse
+    var authzStatus: CLAuthorizationStatus
+    var location: CLLocation
+    
+    public init(authzType: AuthzType, authzStatus: CLAuthorizationStatus, location: CLLocation) {
+        self.authzType = authzType
+        self.authzStatus = authzStatus
+        self.location = location
+    }
 }
 
 public enum LocationAction: Equatable {

--- a/Sources/CoreLocationMiddleware/CoreLocationMiddleware.swift
+++ b/Sources/CoreLocationMiddleware/CoreLocationMiddleware.swift
@@ -36,11 +36,11 @@ public enum AuthzType: Equatable {
 }
 
 public struct DeviceCapabilities: Equatable {
-    let isSignificantLocationChangeAvailable: Bool
-    let isHeadingAvailable: Bool
-    let isMonitoringAvailable: Bool
-    let isRangingAvailable: Bool
-    let isLocationServiceAvailable: Bool
+    public let isSignificantLocationChangeAvailable: Bool
+    public let isHeadingAvailable: Bool
+    public let isMonitoringAvailable: Bool
+    public let isRangingAvailable: Bool
+    public let isLocationServiceAvailable: Bool
 }
 
 

--- a/Sources/CoreLocationMiddleware/CoreLocationMiddleware.swift
+++ b/Sources/CoreLocationMiddleware/CoreLocationMiddleware.swift
@@ -11,8 +11,8 @@ public enum LocationAction: Equatable {
     // Input
     case startMonitoring(AuthzType)
     case stopMonitoring
-    case getAuthorizationStatus
-    case requestAuthorization(AuthzType)
+    case requestAuthorizationStatus
+    case requestAuthorizationType(AuthzType)
     // Output
     case gotPosition(CLLocation)
     case gotAuthzStatus(CLAuthorizationStatus)
@@ -27,7 +27,7 @@ public enum LocationAction: Equatable {
 let locationReducer = Reducer<LocationAction, LocationState> { action, state in
     var state = state
     switch action {
-    case .startMonitoring, .stopMonitoring, .getAuthorizationStatus, .requestAuthorization:
+    case .startMonitoring, .stopMonitoring, .requestAuthorizationStatus, .requestAuthorizationType:
         break
     case .gotAuthzStatus(.authorizedAlways),
          .gotAuthzStatus(.authorizedWhenInUse):
@@ -69,13 +69,13 @@ public final class CoreLocationMiddleware: Middleware {
         switch action {
         case let .startMonitoring(auth): startMonitoring(with: auth)
         case .stopMonitoring: stopMonitoring()
-        case .getAuthorizationStatus:
+        case .requestAuthorizationStatus:
             if #available(iOS 14.0, *) {
                 delegate.output?.dispatch(getAuthzStatus(status: manager.authorizationStatus))
             } else {
                 return
             }
-        case let .requestAuthorization(value):
+        case let .requestAuthorizationType(value):
             switch value {
             case .always:
                 manager.requestAlwaysAuthorization()

--- a/Sources/CoreLocationMiddleware/CoreLocationMiddleware.swift
+++ b/Sources/CoreLocationMiddleware/CoreLocationMiddleware.swift
@@ -1,10 +1,10 @@
 import CoreLocation
 import SwiftRex
 
-public struct LocationState {
-    var authzType: AuthzType = .whenInUse
-    var authzStatus: CLAuthorizationStatus
-    var location: CLLocation
+public struct LocationState: Equatable {
+    public var authzType: AuthzType = .whenInUse
+    public var authzStatus: CLAuthorizationStatus
+    public var location: CLLocation
 }
 
 public enum LocationAction: Equatable {

--- a/Sources/CoreLocationMiddleware/CoreLocationMiddleware.swift
+++ b/Sources/CoreLocationMiddleware/CoreLocationMiddleware.swift
@@ -88,7 +88,7 @@ public final class CoreLocationMiddleware: Middleware {
             if #available(iOS 14.0, *) {
                 delegate.output?.dispatch(getAuthzStatus(status: manager.authorizationStatus))
             } else {
-                return
+                delegate.output?.dispatch(getAuthzStatus(status: CLLocationManager.authorizationStatus()))
             }
         case .requestAuthorizationType:
             switch getState?().authzType {
@@ -146,11 +146,7 @@ class CLDelegate: NSObject, CLLocationManagerDelegate {
     var output: AnyActionHandler<LocationAction>? = nil
     
     func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
-        if #available(iOS 14.0, *) {
             output?.dispatch(getAuthzStatus(status: status))
-        } else {
-            return
-        }
     }
     
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {

--- a/Sources/CoreLocationMiddleware/CoreLocationMiddleware.swift
+++ b/Sources/CoreLocationMiddleware/CoreLocationMiddleware.swift
@@ -38,7 +38,7 @@ public enum AuthzType: Equatable {
 public struct DeviceCapabilities: Equatable {
     public let isSignificantLocationChangeAvailable: Bool
     public let isHeadingAvailable: Bool
-    public let isMonitoringAvailable: Bool
+    public let isRegionMonitoringAvailable: Bool
     public let isRangingAvailable: Bool
     public let isLocationServiceAvailable: Bool
 }
@@ -133,7 +133,7 @@ public final class CoreLocationMiddleware: Middleware {
             DeviceCapabilities(
                 isSignificantLocationChangeAvailable: CLLocationManager.significantLocationChangeMonitoringAvailable(),
                 isHeadingAvailable: CLLocationManager.headingAvailable(),
-                isMonitoringAvailable: CLLocationManager.isMonitoringAvailable(for: CLCircularRegion.self),
+                isRegionMonitoringAvailable: CLLocationManager.isMonitoringAvailable(for: CLCircularRegion.self),
                 isRangingAvailable: CLLocationManager.isRangingAvailable(),
                 isLocationServiceAvailable: CLLocationManager.locationServicesEnabled()
             )

--- a/Sources/CoreLocationMiddleware/CoreLocationMiddleware.swift
+++ b/Sources/CoreLocationMiddleware/CoreLocationMiddleware.swift
@@ -13,6 +13,7 @@ public enum LocationAction: Equatable {
     case stopMonitoring
     case requestAuthorizationStatus
     case requestAuthorizationType
+    case requestPosition
     // Output
     case gotPosition(CLLocation)
     case gotAuthzStatus(CLAuthorizationStatus)
@@ -28,7 +29,11 @@ public enum AuthzType: Equatable {
 let locationReducer = Reducer<LocationAction, LocationState> { action, state in
     var state = state
     switch action {
-    case .startMonitoring, .stopMonitoring, .requestAuthorizationStatus, .requestAuthorizationType:
+    case .startMonitoring,
+         .stopMonitoring,
+         .requestAuthorizationStatus,
+         .requestAuthorizationType,
+         .requestPosition:
         break
     case let .gotAuthzStatus(status): state.authzStatus = status
     case let .gotPosition(position): state.location = position
@@ -55,6 +60,7 @@ public final class CoreLocationMiddleware: Middleware {
         delegate.output = output
         manager.delegate = delegate
     }
+    
     public func handle(action: LocationAction, from dispatcher: ActionSource, afterReducer: inout AfterReducer) {
         switch action {
         case .startMonitoring: startMonitoring()
@@ -74,9 +80,11 @@ public final class CoreLocationMiddleware: Middleware {
             case .none:
                 break
             }
+        case .requestPosition: manager.requestLocation()
         default: return
         }
     }
+    
     func startMonitoring() {
         let stateType = getState?().authzType
         let stateStatus = getState?().authzStatus

--- a/Tests/CoreLocationMiddlewareTests/CoreLocationMiddlewareTests.swift
+++ b/Tests/CoreLocationMiddlewareTests/CoreLocationMiddlewareTests.swift
@@ -16,7 +16,7 @@ final class CoreLocationMiddlewareTests: XCTestCase {
         var after1 = AfterReducer.do {
             print("Test")
         }
-        sut.handle(action: .startMonitoring, from: .here(), afterReducer: &after1)
+        sut.handle(action: .stopMonitoring, from: .here(), afterReducer: &after1)
         after1.reducerIsDone()
 
         XCTAssertEqual(store.actionsReceived, [.stopMonitoring])

--- a/Tests/CoreLocationMiddlewareTests/Mock/TestStore.swift
+++ b/Tests/CoreLocationMiddlewareTests/Mock/TestStore.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import CoreLocation
 
 @testable import SwiftRex
 @testable import CoreLocationMiddleware
@@ -26,7 +27,7 @@ struct AppState: Equatable {
 }
 
 class TestStore {
-    var state: LocationState = LocationState.unknown
+    var state: LocationState = LocationState(authzStatus: .notDetermined, location: CLLocation())
     var actionsReceived: [LocationAction] = []
 
     var getState: (() -> LocationState)!

--- a/Tests/CoreLocationMiddlewareTests/Mock/TestStore.swift
+++ b/Tests/CoreLocationMiddlewareTests/Mock/TestStore.swift
@@ -28,7 +28,7 @@ struct AppState: Equatable {
 
 class TestStore {
     var state: LocationState = LocationState(authzStatus: .notDetermined, location: CLLocation())
-    var actionsReceived: [LocationAction] = []
+    var actionsReceived: [LocationAction] = [.stopMonitoring]
 
     var getState: (() -> LocationState)!
     var actionHandler: AnyActionHandler<LocationAction>!


### PR DESCRIPTION
Introducing : 

- new actions to support requesting the location authorization status and device capabilities 
- the inclusion of a new type to define whether the location service should request "when in use" or "always"
- another new type to collect device capabilities 